### PR TITLE
fix: actualización del post service

### DIFF
--- a/src/modules/posts/dtos/create-post.dto.ts
+++ b/src/modules/posts/dtos/create-post.dto.ts
@@ -1,15 +1,31 @@
 import { JsonValue } from '@prisma/client/runtime/library';
-import { IsObject, IsNumber, IsOptional } from 'class-validator';
+import {
+	IsObject,
+	IsNumber,
+	IsOptional,
+	IsArray,
+	ArrayNotEmpty,
+	ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+class ProviderContent {
+	@IsNumber()
+	provider: number;
+
+	@IsNumber()
+	typePost: number;
+
+	@IsObject()
+	content: Record<string, JsonValue>;
+}
 
 export class CreatePostDto {
-	@IsObject()
-	readonly content: Record<string, JsonValue>;
-
-	@IsNumber()
-	readonly provider: number;
-
-	@IsNumber()
-	readonly typePost: number;
+	@IsArray()
+	@ArrayNotEmpty()
+	@ValidateNested({ each: true })
+	@Type(() => ProviderContent)
+	readonly providerContents: ProviderContent[];
 
 	@IsNumber()
 	@IsOptional()

--- a/src/modules/posts/factories/facebook/facebook.validationProperties.ts
+++ b/src/modules/posts/factories/facebook/facebook.validationProperties.ts
@@ -105,7 +105,7 @@ export class FacebookValidationProperties implements PostValidationProperties {
 			throw new Error(
 				`La relación de aspecto de la imagen (${actualAspectRatio.toFixed(
 					2,
-				)}) no es la recomendada de ${aspectRatio}:1.`,
+				)}) no es la recomendada de ${aspectRatio}`,
 			);
 		}
 	}

--- a/src/modules/posts/factories/instagram/instagram.validationProperties.ts
+++ b/src/modules/posts/factories/instagram/instagram.validationProperties.ts
@@ -16,7 +16,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 	): Promise<void> {
 		if (!fields) {
 			throw new Error(
-				'El campo "fields" es requerido en los datos de entrada.',
+				'El campo "fields" es requerido en los datos de entrada para Instagram.',
 			);
 		}
 		switch (typePostName) {
@@ -27,7 +27,9 @@ export class InstagramValidationProperties implements PostValidationProperties {
 				await this.validateReelProperties(fields, properties);
 				break;
 			default:
-				throw new Error('Tipo de publicación no soportado.');
+				throw new Error(
+					'Tipo de publicación no soportado en Instagram.',
+				);
 		}
 	}
 
@@ -37,7 +39,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 	): Promise<void> {
 		if (typeof fields !== 'object' || fields === null) {
 			throw new Error(
-				'El parámetro "fields y properties" deben ser un objeto.',
+				'El parámetro "fields y properties" deben ser un objeto para Instagram.',
 			);
 		}
 
@@ -50,12 +52,14 @@ export class InstagramValidationProperties implements PostValidationProperties {
 		};
 
 		if (!Array.isArray(images) || images.length === 0) {
-			throw new Error('Debe proporcionarse al menos una URL de imagen.');
+			throw new Error(
+				'Debe proporcionarse al menos una URL de imagen para Instagram.',
+			);
 		}
 
 		if (!validationProperties) {
 			throw new Error(
-				'No se encontraron propiedades de validación para el tipo de publicación.',
+				'No se encontraron propiedades de validación para el tipo de publicación en Instagram.',
 			);
 		}
 
@@ -70,7 +74,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 			// Validar tamaño del archivo
 			if (buffer.length > maxSize) {
 				throw new Error(
-					`El tamaño del archivo ${buffer.length} es mayor al máximo permitido. El tamaño máximo permitido es de ` +
+					`El tamaño del archivo ${buffer.length} es mayor al máximo permitido en Instagram. El tamaño máximo permitido es de ` +
 						maxSize +
 						' bytes.',
 				);
@@ -81,7 +85,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 
 			if (!type || !validFormats.includes(type.mime)) {
 				throw new Error(
-					`El formato del archivo "${type.mime}" no es válido o no soportado. Los formatos permitidos son: ` +
+					`El formato del archivo "${type.mime}" no es válido o no soportado en Instagram. Los formatos permitidos son: ` +
 						validFormats.join(', '),
 				);
 			}
@@ -93,7 +97,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 				dimensions.height < minDimensions.height
 			) {
 				throw new Error(
-					`Las dimensiones  ancho: "${dimensions.width}" y alto: "${dimensions.height}" de la imagen no cumplen con los mínimos requeridos. Las dimensiones mínimas permitidas son ` +
+					`Las dimensiones ancho: "${dimensions.width}" y alto: "${dimensions.height}" de la imagen no cumplen con los mínimos requeridos en Instagram. Las dimensiones mínimas permitidas son ` +
 						minDimensions.width +
 						'x' +
 						minDimensions.height +
@@ -108,14 +112,18 @@ export class InstagramValidationProperties implements PostValidationProperties {
 		properties: JsonValue,
 	): Promise<void> {
 		if (typeof fields !== 'object' || fields === null) {
-			throw new Error('El parámetro "fields" debe ser un objeto.');
+			throw new Error(
+				'El parámetro "fields" debe ser un objeto para Instagram.',
+			);
 		}
 
 		const videoUrl = (fields as Record<string, JsonValue>)
 			.video_url as string;
 
 		if (typeof videoUrl !== 'string' || videoUrl.trim() === '') {
-			throw new Error('Debe proporcionarse una URL válida del video.');
+			throw new Error(
+				'Debe proporcionarse una URL válida del video para Instagram.',
+			);
 		}
 
 		const validationProperties = properties as {
@@ -127,7 +135,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 
 		if (!validationProperties) {
 			throw new Error(
-				'No se encontraron propiedades de validación para el tipo de publicación.',
+				'No se encontraron propiedades de validación para el tipo de publicación en Instagram.',
 			);
 		}
 
@@ -142,7 +150,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 		const size = buffer.length;
 		if (size > maxSize) {
 			throw new Error(
-				`El tamaño del archivo ${size} es mayor al máximo permitido. El tamaño máximo permitido es de ` +
+				`El tamaño del archivo ${size} es mayor al máximo permitido en Instagram. El tamaño máximo permitido es de ` +
 					maxSize +
 					' bytes.',
 			);
@@ -155,7 +163,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 		const duration = await getVideoDurationInSeconds(bufferStream);
 		if (duration < minDuration || duration > maxDuration) {
 			throw new Error(
-				`La duración del video ${duration} segundos no cumple con los límites permitidos. La duración mínima permitida es de ${minDuration} segundos y la duración máxima permitida es de ${maxDuration} segundos.`,
+				`La duración del video ${duration} segundos no cumple con los límites permitidos en Instagram. La duración mínima permitida es de ${minDuration} segundos y la duración máxima permitida es de ${maxDuration} segundos.`,
 			);
 		}
 
@@ -164,7 +172,7 @@ export class InstagramValidationProperties implements PostValidationProperties {
 
 		if (!type || !validFormats.includes(type.mime)) {
 			throw new Error(
-				`El formato del archivo "${type.mime}" no es válido o no soportado. Los formatos permitidos son: ` +
+				`El formato del archivo "${type.mime}" no es válido o no soportado en Instagram. Los formatos permitidos son: ` +
 					validFormats.join(', '),
 			);
 		}

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -54,24 +54,21 @@ export class PostsService extends Service {
 	 * Crea una nueva publicación con las validaciones necesarias.
 	 * @param postData - DTO con los datos de la publicación.
 	 * @param profileId - ID del perfil que crea la publicación.
-	 * @returns La nueva publicación creada.
+	 * @returns Las nuevas publicaciones creadas.
 	 */
-
 	async createPost(
 		postData: CreatePostDto,
 		profileId: number,
-	): Promise<{ post: Post }> {
-		const { typePost, provider, content, unix } = postData;
+	): Promise<{ posts: Post[] }> {
+		const { unix, providerContents } = postData;
 
-		const newPost = await this.processPostCreation(
+		const newPosts = await this.processPostCreation(
 			profileId,
-			typePost,
-			provider,
-			content,
+			providerContents,
 			unix,
 		);
 
-		return { post: newPost };
+		return { posts: newPosts };
 	}
 
 	/**
@@ -218,9 +215,7 @@ export class PostsService extends Service {
 	/**
 	 * Procesa la creación de un post, incluyendo validaciones y manejo de publicación.
 	 * @param profileId - ID del perfil que crea la publicación.
-	 * @param typePost - Tipo de publicación.
-	 * @param provider - Proveedor de la publicación.
-	 * @param content - Contenido de la publicación.
+	 * @param providerContents - Proveedor de la publicación.
 	 * @param unix - Timestamp para programación.
 	 * @returns La nueva publicación creada.
 	 * @throws {BadRequestException} Si alguna validación falla.
@@ -228,87 +223,95 @@ export class PostsService extends Service {
 	 */
 	private async processPostCreation(
 		profileId: number,
-		typePost: number,
-		provider: number,
-		content: Prisma.JsonValue,
+		providerContents: {
+			provider: number;
+			typePost: number;
+			content: Prisma.JsonValue;
+		}[],
 		unix: number,
-	): Promise<Post> {
-		const profile = await this.validateProfile(profileId);
-		if (!profile) {
-			throw new BadRequestException(
-				`No hay perfil asociado con el proveedor "${provider}".`,
+	): Promise<Post[]> {
+		const newPosts: Post[] = [];
+
+		for (const { provider, typePost, content } of providerContents) {
+			const profile = await this.validateProfile(profileId);
+			if (!profile) {
+				throw new BadRequestException(
+					`No hay perfil asociado con el proveedor "${provider}".`,
+				);
+			}
+			const postType = await this.getAndValidatePostType(typePost);
+			if (!postType) {
+				throw new BadRequestException(
+					`Tipo de publicación "${typePost}" no encontrado.`,
+				);
+			}
+			const providerData = await this.getAndValidateProvider(provider);
+			if (!providerData) {
+				throw new BadRequestException(
+					`Proveedor "${provider}" no encontrado.`,
+				);
+			}
+			const providerPostType = await this.validateProviderPostType(
+				providerData.id,
+				postType.id,
 			);
-		}
-		const postType = await this.getAndValidatePostType(typePost);
-		if (!postType) {
-			throw new BadRequestException(
-				`Tipo de publicación "${typePost}" no encontrado.`,
+			if (!providerPostType) {
+				throw new BadRequestException(
+					`Relación proveedor-tipo de publicación no encontrada para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
+				);
+			}
+
+			const contentLimitsValid = await this.validateContentLimits(
+				content,
+				providerPostType,
+				provider,
+				typePost,
 			);
-		}
-		const providerData = await this.getAndValidateProvider(provider);
-		if (!providerData) {
-			throw new BadRequestException(
-				`Proveedor "${provider}" no encontrado.`,
+			if (!contentLimitsValid) {
+				throw new BadRequestException(
+					`El contenido no cumple con los límites de caracteres o campos requeridos para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
+				);
+			}
+			const contentFieldsValid = await this.validateContentFields(
+				content,
+				providerPostType,
+				typePost,
 			);
-		}
-		const providerPostType = await this.validateProviderPostType(
-			providerData.id,
-			postType.id,
-		);
-		if (!providerPostType) {
-			throw new BadRequestException(
-				`Relación proveedor-tipo de publicación no encontrada para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
+			if (!contentFieldsValid) {
+				throw new BadRequestException(
+					`El contenido no cumple con los campos requeridos para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
+				);
+			}
+
+			// Validar propiedades del post
+			const newPost = await this.createPostRecord(
+				postType,
+				providerPostType,
+				profileId,
+				content,
+				unix,
 			);
+			if (!newPost) {
+				throw new BadRequestException(
+					`Error al crear la publicación para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
+				);
+			}
+
+			const handlePostPublication = await this.handlePostPublication(
+				profileId,
+				newPost.id,
+				unix,
+			);
+			if (!handlePostPublication) {
+				throw new BadRequestException(
+					`Error al manejar la publicación para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
+				);
+			}
+
+			newPosts.push(newPost);
 		}
 
-		const contentLimitsValid = await this.validateContentLimits(
-			content,
-			providerPostType,
-			provider,
-			typePost,
-		);
-		if (!contentLimitsValid) {
-			throw new BadRequestException(
-				`El contenido no cumple con los límites de caracteres o campos requeridos para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
-			);
-		}
-		const contentFieldsValid = await this.validateContentFields(
-			content,
-			providerPostType,
-			typePost,
-		);
-		if (!contentFieldsValid) {
-			throw new BadRequestException(
-				`El contenido no cumple con los campos requeridos para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
-			);
-		}
-
-		// Validar propiedades del post
-		const newPost = await this.createPostRecord(
-			postType,
-			providerPostType,
-			profileId,
-			content,
-			unix,
-		);
-		if (!newPost) {
-			throw new BadRequestException(
-				`Error al crear la publicación para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
-			);
-		}
-
-		const handlePostPublication = await this.handlePostPublication(
-			profileId,
-			newPost.id,
-			unix,
-		);
-		if (!handlePostPublication) {
-			throw new BadRequestException(
-				`Error al manejar la publicación para el proveedor "${provider}" y tipo de publicación "${typePost}".`,
-			);
-		}
-
-		return newPost;
+		return newPosts;
 	}
 
 	/**


### PR DESCRIPTION
🔧 Mejoras realizadas:
✅ Se actualizo la extructura para crear un post, se realizo un cambio en el cuerpo de como el cliente debe enviar la solicitud para crear un Post permitiendo publicar en multiples plataformas al mismo tiempo en una sola solicitud.
-------------------------------- 🚀 🚀  🚀Cuerpo de la solicitud 🚀 🚀 🚀 -----------------------------------------------------
{
    "providerContents": [
        {
            "provider": 1, ➡️ Facebook
            "typePost": 3, ➡️ Post tipo imagen
            "content": {
                "url":"",
                "message":"Prueba en multiples providers"
            },
            "unix":123 ➡️ Fecha pblicación 
        },
        {
            "provider": 3, ➡️ Instagram
            "typePost": 3, ➡️ Post tipo imagen 
            "content": {
                "image_url":[""],
                "caption":"Prueba en multiples providers"
            },
            "unix":123 ➡️ Fecha publicación
        }
    ]
}
