### PR TITLE
feat: Añadir servicio de notificación y payloads para eventos de publ…

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@nestjs/bull": "^10.2.3",
 		"@nestjs/common": "^10.4.15",
 		"@nestjs/core": "^10.4.15",
+		"@nestjs/event-emitter": "^2.1.1",
 		"@nestjs/jwt": "^10.2.0",
 		"@nestjs/mapped-types": "^2.0.6",
 		"@nestjs/passport": "^10.0.3",

--- a/src/modules/notification/interface/notification.payloads.ts
+++ b/src/modules/notification/interface/notification.payloads.ts
@@ -1,0 +1,18 @@
+export interface PostScheduledPayload {
+	postId: number;
+	email: string;
+}
+
+export interface PostPublishedPayload {
+	postId: number;
+	email: string;
+}
+
+export interface PostRescheduledPayload {
+	postId: number;
+	email: string;
+}
+
+export interface EmailSentPayload {
+	email: string;
+}

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { EmailService } from '../email/email.service';
+import {
+	EmailSentPayload,
+	PostPublishedPayload,
+	PostRescheduledPayload,
+	PostScheduledPayload,
+} from './interface/notification.payloads';
+
+@Injectable()
+export class NotificationService {
+	constructor(private readonly emailService: EmailService) {}
+
+	@OnEvent('post.scheduled')
+	handlePostScheduledEvent(payload: PostScheduledPayload) {
+		this.emailService
+			.to(payload.email)
+			.subject('Nueva publicación programada')
+			.text(
+				`Se ha programado una nueva publicación con ID: ${payload.postId}`,
+			)
+			.send();
+	}
+
+	@OnEvent('post.published')
+	handlePostPublishedEvent(payload: PostPublishedPayload) {
+		this.emailService
+			.to(payload.email)
+			.subject('Publicación realizada')
+			.text(`Se ha publicado el post con ID: ${payload.postId}`)
+			.send();
+	}
+
+	@OnEvent('post.rescheduled')
+	handlePostRescheduledEvent(payload: PostRescheduledPayload) {
+		this.emailService
+			.to(payload.email)
+			.subject('Publicación reprogramada')
+			.text(`Se ha reprogramado el post con ID: ${payload.postId}`)
+			.send();
+	}
+
+	@OnEvent('email.sent')
+	handleEmailSentEvent(payload: EmailSentPayload) {
+		this.emailService
+			.to(payload.email)
+			.subject('Nuevo correo enviado')
+			.text(`Se ha enviado un nuevo correo a: ${payload.email}`)
+			.send();
+	}
+}


### PR DESCRIPTION
🟢 Se implemento notification.service para notificar a los clientes por email de cambios realizados.
🟢 Se utilizó el servicio de email.service como intermediario para notificar por ese medio