### PR TITLE
feat: Permitir múltiples correos electrónicos en los payloads de notificación

### DIFF
--- a/src/modules/notification/interface/notification.payloads.ts
+++ b/src/modules/notification/interface/notification.payloads.ts
@@ -1,18 +1,18 @@
 export interface PostScheduledPayload {
 	postId: number;
-	email: string;
+	email: string | string[];
 }
 
 export interface PostPublishedPayload {
 	postId: number;
-	email: string;
+	email: string | string[];
 }
 
 export interface PostRescheduledPayload {
 	postId: number;
-	email: string;
+	email: string | string[];
 }
 
 export interface EmailSentPayload {
-	email: string;
+	email: string | string[];
 }

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -2,51 +2,59 @@ import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { EmailService } from '../email/email.service';
 import {
-	EmailSentPayload,
+	PostScheduledPayload,
 	PostPublishedPayload,
 	PostRescheduledPayload,
-	PostScheduledPayload,
+	EmailSentPayload,
 } from './interface/notification.payloads';
 
 @Injectable()
 export class NotificationService {
 	constructor(private readonly emailService: EmailService) {}
 
+	private sendEmail(to: string | string[], subject: string, text: string) {
+		if (Array.isArray(to)) {
+			to.forEach((email) => {
+				this.emailService.to(email).subject(subject).text(text).send();
+			});
+		} else {
+			this.emailService.to(to).subject(subject).text(text).send();
+		}
+	}
+
 	@OnEvent('post.scheduled')
 	handlePostScheduledEvent(payload: PostScheduledPayload) {
-		this.emailService
-			.to(payload.email)
-			.subject('Nueva publicación programada')
-			.text(
-				`Se ha programado una nueva publicación con ID: ${payload.postId}`,
-			)
-			.send();
+		this.sendEmail(
+			payload.email,
+			'Nueva publicación programada',
+			`Se ha programado una nueva publicación con ID: ${payload.postId}`,
+		);
 	}
 
 	@OnEvent('post.published')
 	handlePostPublishedEvent(payload: PostPublishedPayload) {
-		this.emailService
-			.to(payload.email)
-			.subject('Publicación realizada')
-			.text(`Se ha publicado el post con ID: ${payload.postId}`)
-			.send();
+		this.sendEmail(
+			payload.email,
+			'Publicación realizada',
+			`Se ha publicado el post con ID: ${payload.postId}`,
+		);
 	}
 
 	@OnEvent('post.rescheduled')
 	handlePostRescheduledEvent(payload: PostRescheduledPayload) {
-		this.emailService
-			.to(payload.email)
-			.subject('Publicación reprogramada')
-			.text(`Se ha reprogramado el post con ID: ${payload.postId}`)
-			.send();
+		this.sendEmail(
+			payload.email,
+			'Publicación reprogramada',
+			`Se ha reprogramado el post con ID: ${payload.postId}`,
+		);
 	}
 
 	@OnEvent('email.sent')
 	handleEmailSentEvent(payload: EmailSentPayload) {
-		this.emailService
-			.to(payload.email)
-			.subject('Nuevo correo enviado')
-			.text(`Se ha enviado un nuevo correo a: ${payload.email}`)
-			.send();
+		this.sendEmail(
+			payload.email,
+			'Nuevo correo enviado',
+			`Se ha enviado un nuevo correo a: ${payload.email}`,
+		);
 	}
 }


### PR DESCRIPTION
Se actualizo el servicio de notificaciones para que sea opcional poder notificar a los miembros que asociados a una cuenta principal.