### PR TITLE
feat: Integrar servicio de notificación y soporte para correos electr…

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,10 +7,17 @@ import { JwtService } from '@nestjs/jwt';
 import { LoggerConfiguredModule } from './lib/Logger';
 import { S3GlobalModule } from './common/s3-config/s3-module';
 import { S3Service } from './common/s3-config';
+import { NotificationService } from './modules/notification/notification.service';
 
 @Module({
 	imports: [...Modules, LoggerConfiguredModule, S3GlobalModule.register()],
 	controllers: [AppController],
-	providers: [PrismaService, ResponseInterceptor, JwtService, S3Service],
+	providers: [
+		PrismaService,
+		ResponseInterceptor,
+		JwtService,
+		S3Service,
+		NotificationService,
+	],
 })
 export class AppModule {}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -10,6 +10,7 @@ import { CustomerModule } from '../modules/customer/customer.module';
 import { StorageModule } from 'src/modules/storage/storage.module';
 import { ShopifyModule } from 'src/modules/shopify/shopify.module';
 import { WebsocketModule } from 'src/modules/websocket/websocket.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 const CoreModules = [
 	SetupModule,
@@ -18,6 +19,7 @@ const CoreModules = [
 	CustomerModule,
 	StorageModule,
 	ShopifyModule,
+	EventEmitterModule.forRoot(),
 ];
 
 const AuthModules = [AuthModule];

--- a/src/modules/posts/dtos/create-post.dto.ts
+++ b/src/modules/posts/dtos/create-post.dto.ts
@@ -30,4 +30,7 @@ export class CreatePostDto {
 	@IsNumber()
 	@IsOptional()
 	readonly unix?: number;
+
+	@IsOptional()
+	readonly email?: string | string[];
 }

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -40,12 +40,14 @@ import {
 	TransformedPost,
 } from './dtos/transformed-post.interface';
 import { JsonValue } from '@prisma/client/runtime/library';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class PostsService extends Service {
 	constructor(
 		private readonly prisma: PrismaService,
 		private readonly taskQueueService: TaskQueueService,
+		private readonly eventEmitter: EventEmitter2,
 	) {
 		super(PostsService.name);
 	}
@@ -60,12 +62,13 @@ export class PostsService extends Service {
 		postData: CreatePostDto,
 		profileId: number,
 	): Promise<{ posts: Post[] }> {
-		const { unix, providerContents } = postData;
+		const { unix, providerContents, email } = postData;
 
 		const newPosts = await this.processPostCreation(
 			profileId,
 			providerContents,
 			unix,
+			email,
 		);
 
 		return { posts: newPosts };
@@ -83,10 +86,17 @@ export class PostsService extends Service {
 		profileId: number,
 		postId: number,
 		newUnixTime: number,
+		email?: string | string[],
 	): Promise<{ post: Post }> {
 		const post = await this.findAndValidatePost(profileId, postId);
 		await this.validatePostStatus(post);
-		await this.updateScheduledTask(post, profileId, postId, newUnixTime);
+		await this.updateScheduledTask(
+			post,
+			profileId,
+			postId,
+			newUnixTime,
+			email,
+		);
 		const updatedPost = {
 			...post,
 			task: { status: TaskStatus.PENDING, unix: newUnixTime },
@@ -229,6 +239,7 @@ export class PostsService extends Service {
 			content: Prisma.JsonValue;
 		}[],
 		unix: number,
+		email?: string | string[],
 	): Promise<Post[]> {
 		const newPosts: Post[] = [];
 
@@ -301,6 +312,7 @@ export class PostsService extends Service {
 				profileId,
 				newPost.id,
 				unix,
+				email,
 			);
 			if (!handlePostPublication) {
 				throw new BadRequestException(
@@ -326,11 +338,24 @@ export class PostsService extends Service {
 		profileId: number,
 		postId: number,
 		unix?: number,
+		email?: string | string[],
 	): Promise<boolean> {
 		if (unix) {
 			await this.taskQueueService.scheduleTask(profileId, postId, unix);
+			if (email) {
+				this.eventEmitter.emit('post.scheduled', {
+					postId,
+					email,
+				});
+			}
 		} else {
 			await this.publishPost(profileId, postId);
+			if (email) {
+				this.eventEmitter.emit('post.published', {
+					postId,
+					email,
+				});
+			}
 		}
 		return true;
 	}
@@ -1062,6 +1087,7 @@ export class PostsService extends Service {
 		profileId: number,
 		postId: number,
 		newUnixTime: number,
+		email?: string | string[],
 	): Promise<void> {
 		try {
 			await Promise.all([
@@ -1075,6 +1101,10 @@ export class PostsService extends Service {
 				this.prisma.task.update({
 					where: { id: post.task.id },
 					data: { unix: newUnixTime },
+				}),
+				this.eventEmitter.emit('post.rescheduled', {
+					postId,
+					email,
 				}),
 			]);
 		} catch (error) {

--- a/src/modules/shopify/shopify.service.ts
+++ b/src/modules/shopify/shopify.service.ts
@@ -279,7 +279,7 @@ export class ShopifyService {
 	private async listWebhooks(
 		shop: string,
 		accessToken: string,
-	): Promise<object[]> {
+	): Promise<{ id: number; topic: string }[]> {
 		try {
 			const response = await axios.get(
 				`${this.baseUrl(shop)}/webhooks.json`,
@@ -345,7 +345,9 @@ export class ShopifyService {
 
 			// Filtrar los webhooks que coincidan con el mismo topic y dirección
 			for (const webhook of existingWebhooks) {
-				if (webhook.topic === topic) {
+				if (
+					(webhook as { id: number; topic: string }).topic === topic
+				) {
 					// Eliminar el webhook existente
 					await this.deleteWebhook(shop, accessToken, webhook.id);
 				}


### PR DESCRIPTION
Integracion del servicio de notificaciones en posts.service para notificar al usuario cuando se haga una pulicacion o actualzacion de esta. Por lo pronto el paramétro nuevo qu es email esta opcional para no romper las las integracion actual con el frontend.